### PR TITLE
fix(install): netcdf not found when installing on CSC

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ https://www.helsinki.fi/fi/unitube/video/80d7a662-f60d-4cd1-b648-31dd0cbe9bd2
 How to install on Puhti/CSC:
 ----------------------------
 1) Go to directory install/
-2) run install_on_csc.sh (e.g. "sh install_on_csc.sh")
+2) run install_on_csc.sh (`sh install_on_csc.sh <cluster>`, where `<cluster>` can be one of `puhti, mahti, lumi`)
 3) follow the instructions. If the compiling step does not work for some reason, you can try running the install script
-   again but omit the compiling. Then navigate to ARCA root dir and try compiling there again (with command "make").
+   again but omit the compiling. Then navigate to ARCA root dir and try compiling there again (with command `make CLUSTER=<cluster>`).
    In the "makefile", you might want to change the code optimization to O2 or even O3 (default is O1).
 
 

--- a/install/install_on_csc.sh
+++ b/install/install_on_csc.sh
@@ -1,7 +1,33 @@
 #!/bin/bash
 
-module load gcc/9.1.0
-module load netcdf/4.7.0
-module load netcdf-fortran/4.4.4
 
-python3 setup.py --csc
+cluster=$1
+
+case "$cluster" in
+    puhti)
+        module load python-data
+        module load gcc
+        module load netcdf-c
+        module load netcdf-fortran
+        ;;
+    mahti)
+        module load python-data
+        module load gcc
+        module load netcdf-c
+        module load netcdf-fortran
+        ;;
+    lumi)
+        module purge
+        module load cray-python
+        module load PrgEnv-gnu
+        module load cray-hdf5
+        module load cray-netcdf
+        module load craype-x86-rome  # target architecture of login node
+        ;;
+    *)
+        echo "Usage: $0 {puhti|mahti|lumi}"
+        exit 1
+        ;;
+esac
+
+python3 setup.py --csc "$cluster"

--- a/install/makefiles_for_manual_installation/makefile_for_csc
+++ b/install/makefiles_for_manual_installation/makefile_for_csc
@@ -11,20 +11,23 @@
 # Or this
 # NETLIBS = -I$(NETCDF_INCLUDE) -L$(NETCDF_LIB) -L$(H5_LIB) -lnetcdf -lnetcdff -lcurl -lhdf5 -lhdf5_hl
 
-# On CSC/Puhti ------------------------------------------------------
-NETLIBS =  -I/appl/spack/install-tree/gcc-9.1.0/netcdf-fortran-4.4.4-4tj6tj/include \
-							-L/appl/spack/install-tree/gcc-9.1.0/netcdf-fortran-4.4.4-4tj6tj/lib -lnetcdff -lnetcdf -lnetcdf
-
-# Load the correct modules before compiling and running:
-# module load python-data/3.7.6-1
-# module load gcc/9.1.0
-# module load netcdf/4.7.0
-# module load netcdf-fortran/4.4.4%s
+# On CSC ------------------------------------------------------
+CLUSTER ?= puhti
+ifeq ($(CLUSTER),puhti)
+	NETLIBS = -I$(NETCDF_FORTRAN_INSTALL_ROOT)/include -L$(NETCDF_FORTRAN_INSTALL_ROOT)/lib -lnetcdff -lnetcdf
+endif
+ifeq ($(CLUSTER),mahti)
+	NETLIBS = -I$(NETCDF_FORTRAN_INSTALL_ROOT)/include -L$(NETCDF_FORTRAN_INSTALL_ROOT)/lib -lnetcdff -lnetcdf
+endif
+ifeq ($(CLUSTER),lumi)
+	F90 = ftn
+	NETLIBS =
+endif
 # ------------------------------- end NETCDF configuring ---------------------------------------
 
 
 # compiler
-F90 = gfortran
+F90 ?= gfortran
 
 COPTI = -O2
 BOPTI = -O2
@@ -92,7 +95,8 @@ arcabox.exe: $(OD)/arcabox.o $(BOX_OBJECTS) $(CHEM_OBJECTS) $(ACDC_OBJECTS) $(PS
 	$(F90) $(BOX_OPTS) $^ -o $@ $(NETLIBS)
 
 test:
-		@echo ${BOX_OPTS}
+	@echo $(BOX_OPTS)
+	@echo $(NETLIBS)
 
 #
 reactions:

--- a/install/setup.py
+++ b/install/setup.py
@@ -40,6 +40,13 @@ operatingsystem = platform.system()
 # "Windows"/"Linux"/"Darwin"
 
 csc = '--csc' in sys.argv
+if csc:
+    idx = sys.argv.index('--csc')
+    if idx + 1 < len(sys.argv):
+        cluster = sys.argv[idx+1]
+    else:
+        print("Please specify cluster among [puhti, mahti, lumi]")
+        
 
 out = 0
 curr_path = os.path.split(os.getcwd())[0]
@@ -53,7 +60,7 @@ if python == '':
 if not os.path.exists('makefile'):
     # write makefile
     if csc:
-        filename = 'makefile_for_csc_puhti'
+        filename = 'makefile_for_csc'
     elif (operatingsystem == 'Linux' or operatingsystem == 'Windows'):
         filename = 'makefile_for_linux_and_win'
     elif operatingsystem == 'Darwin':
@@ -98,7 +105,10 @@ if comp == 'y' or comp == 'Y':
     print("This will take a while, have patience...")
     print()
 
-    out = os.system("make")
+    if csc:
+        out = os.system(f"make CLUSTER={cluster}")
+    else:
+        out = os.system("make")
     if out == 0:
         print("+------------------------------------------+\n")
         print("Compiling of arcabox.exe was succesful!\n")
@@ -115,16 +125,23 @@ if out == 0:
         f.write('#!/bin/bash%s'%le)
         f.write('%s'%le)
     if csc:
-        f.write('module load python-data/3.7.6-1%s'%le)
-        f.write('module load gcc/9.1.0%s'%le)
-        f.write('module load netcdf/4.7.0%s'%le)
-        f.write('module load netcdf-fortran/4.4.4%s'%le)
+        if cluster in ("puhti", "mahti"):
+            f.write('module load python-data%s'%le)
+            f.write('module load gcc%s'%le)
+            f.write('module load netcdf-c%s'%le)
+            f.write('module load netcdf-fortran%s'%le)
+        elif cluster == "lumi":
+            f.write('module load cray-python%s'%le)
+            f.write('module load PrgEnv-gnu%s'%le)
+            f.write('module load cray-hdf5%s'%le)
+            f.write('module load cray-netcdf%s'%le)
+            f.write('module load craype-x86-rome%s'%le)
     elif operatingsystem != 'Windows':
         f.write('# If you are using the user interface on CSC, uncomment next 4 lines%s'%le)
-        f.write('# module load python-data/3.7.6-1%s'%le)
-        f.write('# module load gcc/9.1.0%s'%le)
-        f.write('# module load netcdf/4.7.0%s'%le)
-        f.write('# module load netcdf-fortran/4.4.4%s'%le)
+        f.write('# module load python-data%s'%le)
+        f.write('# module load gcc%s'%le)
+        f.write('# module load netcdf-c%s'%le)
+        f.write('# module load netcdf-fortran%s'%le)
         f.write('%s'%le)
 
     if not csc:


### PR DESCRIPTION
- Drop hardcoded NetCDF versions on Puhti/Mahti (previous ones outdated).
- Additional augument to install_on_csc.sh, setup.py and make_file_for_csc to seperate lumi install.
- Remove "puhti" suffix from template Makefile name.
- Use NetCDF module environment variables to set include and lib paths.
- Update README.md accordingly.

Known issue:
- On lumi, compilation and arcabox.exe works, but GUI fails with following msg:
> "sh run_arca.sh
ARCA Box Model 1.3.3 started at: September 24 2025, 19:10:31 qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found. This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem. Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, webgl, xcb. run_arca.sh: line 18: 255780 Aborted `python3 ModelLib/gui/ARCA_gui.py $organic_compoundlist $inorganic_compoundlist $scaling $scaleall`"